### PR TITLE
[Feature] #21 - 뉴스 크롤링 API구현 (네이버뉴스기준)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -50,6 +50,9 @@ dependencies {
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testImplementation 'org.springframework.security:spring-security-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+
+	// 크롤링
+	implementation 'org.jsoup:jsoup:1.17.2'
 }
 
 tasks.named('test') {

--- a/src/main/java/dgu/newsee/domain/news/controller/NewsController.java
+++ b/src/main/java/dgu/newsee/domain/news/controller/NewsController.java
@@ -1,0 +1,34 @@
+package dgu.newsee.domain.news.controller;
+
+import dgu.newsee.domain.news.dto.NewsCrawlRequestDTO;
+import dgu.newsee.domain.news.dto.NewsCrawlResponseDTO;
+import dgu.newsee.domain.news.entity.News;
+import dgu.newsee.domain.news.service.NewsService;
+import dgu.newsee.global.payload.ApiResponse;
+import dgu.newsee.global.payload.ResponseCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/url/news")
+@RequiredArgsConstructor
+public class NewsController {
+
+    private final NewsService newsService;
+
+    @PostMapping
+    public ApiResponse<?> crawlNews(@RequestBody NewsCrawlRequestDTO request) {
+        try {
+            News news = newsService.crawlAndSave(request);
+            return ApiResponse.success(
+                    new NewsCrawlResponseDTO(news), ResponseCode.COMMON_SUCCESS
+            );
+        } catch (IllegalArgumentException e) {
+            return ApiResponse.failure(ResponseCode.NEWS_NOT_FOUND.getReason());
+        } catch (Exception e) {
+            return ApiResponse.failure(ResponseCode.COMMON_FAIL.getReason());
+
+        }
+    }
+}
+

--- a/src/main/java/dgu/newsee/domain/news/controller/NewsController.java
+++ b/src/main/java/dgu/newsee/domain/news/controller/NewsController.java
@@ -6,7 +6,9 @@ import dgu.newsee.domain.news.entity.News;
 import dgu.newsee.domain.news.service.NewsService;
 import dgu.newsee.global.payload.ApiResponse;
 import dgu.newsee.global.payload.ResponseCode;
+import dgu.newsee.global.security.CustomUserDetails;
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
@@ -17,18 +19,27 @@ public class NewsController {
     private final NewsService newsService;
 
     @PostMapping
-    public ApiResponse<?> crawlNews(@RequestBody NewsCrawlRequestDTO request) {
+    public ApiResponse<?> crawlNews(
+            @RequestBody NewsCrawlRequestDTO request,
+            @AuthenticationPrincipal CustomUserDetails userDetails) {
+
+        // 로그인 여부 확인
+        if (userDetails == null) {
+            return ApiResponse.failure(ResponseCode.USER_UNAUTHORIZED.getReason());
+        }
+
         try {
-            News news = newsService.crawlAndSave(request);
+            Long userId = userDetails.getUserId();
+            News news = newsService.crawlAndSave(request, userId);
+
             return ApiResponse.success(
-                    new NewsCrawlResponseDTO(news), ResponseCode.COMMON_SUCCESS
+                    new NewsCrawlResponseDTO(news),
+                    ResponseCode.COMMON_SUCCESS
             );
         } catch (IllegalArgumentException e) {
             return ApiResponse.failure(ResponseCode.NEWS_NOT_FOUND.getReason());
         } catch (Exception e) {
             return ApiResponse.failure(ResponseCode.COMMON_FAIL.getReason());
-
         }
     }
 }
-

--- a/src/main/java/dgu/newsee/domain/news/dto/NewsCrawlRequestDTO.java
+++ b/src/main/java/dgu/newsee/domain/news/dto/NewsCrawlRequestDTO.java
@@ -1,0 +1,8 @@
+package dgu.newsee.domain.news.dto;
+
+import lombok.Getter;
+
+@Getter
+public class NewsCrawlRequestDTO {
+    private String url;
+}

--- a/src/main/java/dgu/newsee/domain/news/dto/NewsCrawlResponseDTO.java
+++ b/src/main/java/dgu/newsee/domain/news/dto/NewsCrawlResponseDTO.java
@@ -1,0 +1,26 @@
+package dgu.newsee.domain.news.dto;
+
+import dgu.newsee.domain.news.entity.News;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+public class NewsCrawlResponseDTO {
+    private String title;
+    private String content;
+    private String category;
+    private String source;
+    private LocalDateTime time;
+    private Long newsId;
+
+    public NewsCrawlResponseDTO(News news) {
+        this.title = news.getTitle();
+        this.content = news.getContent();
+        this.category = news.getCategory();
+        this.source = news.getSource();
+        this.time = news.getTime();
+        this.newsId = news.getId();
+    }
+}
+

--- a/src/main/java/dgu/newsee/domain/news/entity/News.java
+++ b/src/main/java/dgu/newsee/domain/news/entity/News.java
@@ -1,0 +1,31 @@
+package dgu.newsee.domain.news.entity;
+import dgu.newsee.global.common.BaseEntity;
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+public class News extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String title;
+
+    @Lob
+    private String content;
+
+    private String category;
+
+    private String source;
+
+    private LocalDateTime time;
+
+    private String originalUrl;
+}

--- a/src/main/java/dgu/newsee/domain/news/entity/SavedNews.java
+++ b/src/main/java/dgu/newsee/domain/news/entity/SavedNews.java
@@ -1,0 +1,34 @@
+package dgu.newsee.domain.news.entity;
+
+import dgu.newsee.domain.news.entity.News;
+import dgu.newsee.domain.user.entity.User;
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+@Entity
+@IdClass(SavedNewsId.class)
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class SavedNews {
+
+    @Id
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id")
+    private User user;
+
+    @Id
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "news_id")
+    private News news;
+
+    private LocalDateTime savedAt;
+
+    @PrePersist
+    protected void onCreate() {
+        this.savedAt = LocalDateTime.now();
+    }
+}

--- a/src/main/java/dgu/newsee/domain/news/entity/SavedNewsId.java
+++ b/src/main/java/dgu/newsee/domain/news/entity/SavedNewsId.java
@@ -1,0 +1,29 @@
+package dgu.newsee.domain.news.entity;
+
+import java.io.Serializable;
+import java.util.Objects;
+
+public class SavedNewsId implements Serializable {
+    private Long user;
+    private Long news;
+
+    public SavedNewsId() {}
+
+    public SavedNewsId(Long user, Long news) {
+        this.user = user;
+        this.news = news;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        SavedNewsId that = (SavedNewsId) o;
+        return Objects.equals(user, that.user) && Objects.equals(news, that.news);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(user, news);
+    }
+}

--- a/src/main/java/dgu/newsee/domain/news/repository/NewsRepository.java
+++ b/src/main/java/dgu/newsee/domain/news/repository/NewsRepository.java
@@ -1,0 +1,8 @@
+package dgu.newsee.domain.news.repository;
+
+import dgu.newsee.domain.news.entity.News;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface NewsRepository extends JpaRepository<News, Long> {
+    boolean existsByOriginalUrl(String url);
+}

--- a/src/main/java/dgu/newsee/domain/news/repository/SavedNewsRepository.java
+++ b/src/main/java/dgu/newsee/domain/news/repository/SavedNewsRepository.java
@@ -1,0 +1,11 @@
+package dgu.newsee.domain.news.repository;
+
+import dgu.newsee.domain.news.entity.SavedNews;
+import dgu.newsee.domain.news.entity.SavedNewsId;
+import dgu.newsee.domain.user.entity.User;
+import dgu.newsee.domain.news.entity.News;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface SavedNewsRepository extends JpaRepository<SavedNews, SavedNewsId> {
+    boolean existsByUserAndNews(User user, News news);
+}

--- a/src/main/java/dgu/newsee/domain/news/service/NewsService.java
+++ b/src/main/java/dgu/newsee/domain/news/service/NewsService.java
@@ -1,0 +1,46 @@
+package dgu.newsee.domain.news.service;
+
+
+import dgu.newsee.domain.news.dto.NewsCrawlRequestDTO;
+import dgu.newsee.domain.news.util.NewsCrawlResult;
+import dgu.newsee.domain.news.entity.News;
+import dgu.newsee.domain.news.repository.NewsRepository;
+import dgu.newsee.domain.news.util.NewsCrawler;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class NewsService {
+
+    private final NewsCrawler crawler;
+    private final NewsRepository newsRepository;
+
+    @Transactional
+    public News crawlAndSave(NewsCrawlRequestDTO request) {
+        String url = request.getUrl();
+
+        if (newsRepository.existsByOriginalUrl(url)) {
+            throw new IllegalArgumentException("이미 저장된 뉴스입니다.");
+        }
+
+        try {
+            NewsCrawlResult result = crawler.crawl(url);
+
+            News news = News.builder()
+                    .title(result.getTitle())
+                    .content(result.getContent())
+                    .category(result.getCategory())
+                    .source(result.getSource())
+                    .time(result.getTime())
+                    .originalUrl(url)
+                    .build();
+
+            return newsRepository.save(news);
+        } catch (Exception e) {
+            throw new RuntimeException("크롤링 실패: " + e.getMessage());
+        }
+    }
+}
+

--- a/src/main/java/dgu/newsee/domain/news/service/NewsService.java
+++ b/src/main/java/dgu/newsee/domain/news/service/NewsService.java
@@ -1,11 +1,14 @@
 package dgu.newsee.domain.news.service;
 
-
 import dgu.newsee.domain.news.dto.NewsCrawlRequestDTO;
-import dgu.newsee.domain.news.util.NewsCrawlResult;
 import dgu.newsee.domain.news.entity.News;
 import dgu.newsee.domain.news.repository.NewsRepository;
+import dgu.newsee.domain.news.util.NewsCrawlResult;
 import dgu.newsee.domain.news.util.NewsCrawler;
+import dgu.newsee.domain.user.entity.User;
+import dgu.newsee.domain.user.repository.UserRepository;
+import dgu.newsee.domain.news.entity.SavedNews;
+import dgu.newsee.domain.news.repository.SavedNewsRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -16,18 +19,23 @@ public class NewsService {
 
     private final NewsCrawler crawler;
     private final NewsRepository newsRepository;
+    private final UserRepository userRepository;
+    private final SavedNewsRepository savedNewsRepository;
 
     @Transactional
-    public News crawlAndSave(NewsCrawlRequestDTO request) {
+    public News crawlAndSave(NewsCrawlRequestDTO request, Long userId) {
         String url = request.getUrl();
 
+        // 중복 저장 방지
         if (newsRepository.existsByOriginalUrl(url)) {
             throw new IllegalArgumentException("이미 저장된 뉴스입니다.");
         }
 
         try {
+            // 뉴스 크롤링
             NewsCrawlResult result = crawler.crawl(url);
 
+            // News 객체 저장
             News news = News.builder()
                     .title(result.getTitle())
                     .content(result.getContent())
@@ -36,11 +44,23 @@ public class NewsService {
                     .time(result.getTime())
                     .originalUrl(url)
                     .build();
+            newsRepository.save(news);
 
-            return newsRepository.save(news);
+            // 사용자 조회
+            User user = userRepository.findById(userId)
+                    .orElseThrow(() -> new IllegalArgumentException("사용자를 찾을 수 없습니다."));
+
+            // 사용자와 뉴스 연결 (SavedNews 테이블에 저장)
+            SavedNews savedNews = SavedNews.builder()
+                    .user(user)
+                    .news(news)
+                    .build();
+            savedNewsRepository.save(savedNews);
+
+            return news;
+
         } catch (Exception e) {
             throw new RuntimeException("크롤링 실패: " + e.getMessage());
         }
     }
 }
-

--- a/src/main/java/dgu/newsee/domain/news/util/NewsCrawlResult.java
+++ b/src/main/java/dgu/newsee/domain/news/util/NewsCrawlResult.java
@@ -1,0 +1,17 @@
+package dgu.newsee.domain.news.util;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@AllArgsConstructor
+public class NewsCrawlResult {
+    private String title;
+    private String content;
+    private String category;
+    private String source;
+    private LocalDateTime time;
+}
+

--- a/src/main/java/dgu/newsee/domain/news/util/NewsCrawler.java
+++ b/src/main/java/dgu/newsee/domain/news/util/NewsCrawler.java
@@ -1,0 +1,44 @@
+package dgu.newsee.domain.news.util;
+
+import dgu.newsee.domain.news.util.NewsCrawlResult;
+import org.jsoup.Jsoup;
+import org.jsoup.nodes.Document;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+
+@Component
+public class NewsCrawler {
+
+    public NewsCrawlResult crawl(String url) throws IOException {
+        Document doc = Jsoup.connect(url).get();
+
+        // 제목
+        String title = doc.select("meta[property=og:title]").attr("content");
+
+        // 본문
+        String content = doc.select("#dic_area").text();
+
+        // 카테고리 추출 (네이버는 명확하게 드러나진 않음 → default로 지정)
+        String category = "기타";
+
+        // 출처 (언론사 이름)
+        String source = doc.select("meta[property=og:article:author]").attr("content");
+        if (source.isBlank()) {
+            source = doc.select("meta[property=og:site_name]").attr("content"); // fallback
+        }
+
+        // 작성 시간 (문자열 → LocalDateTime 파싱)
+        String rawTime = doc.select("meta[property=og:article:published_time]").attr("content");
+        LocalDateTime time;
+        try {
+            time = LocalDateTime.parse(rawTime, DateTimeFormatter.ISO_OFFSET_DATE_TIME);
+        } catch (Exception e) {
+            time = LocalDateTime.now(); // fallback
+        }
+
+        return new NewsCrawlResult(title, content, category, source, time);
+    }
+}

--- a/src/main/java/dgu/newsee/global/config/SecurityConfig.java
+++ b/src/main/java/dgu/newsee/global/config/SecurityConfig.java
@@ -35,7 +35,8 @@ public class SecurityConfig {
                                 "/",
                                 "/swagger-ui/**",
                                 "/v3/api-docs/**",
-                                "/api/user/kakao"
+                                "/api/user/kakao",
+                                "/api/url/news"
                         ).permitAll()
                         .anyRequest().authenticated()
                 )


### PR DESCRIPTION
## Related Issue 🍀
- #21 

<br>

## Key Changes 🔑
- `NewsController` 추가 및 `/api/url/news` 엔드포인트 생성
- `NewsCrawler` 유틸 클래스 구현 (Jsoup 기반 크롤링)
- `NewsService`에서 유효성 검증 + 저장 로직 처리
- `News`, `NewsRepository` 도메인 구성
- DTO (요청/응답) 설계 및 반환 포맷 일관화 (`ApiResponse`)
- 카카오 로그인 기반 accessToken 활용하여 테스트 완료

<br>

## To Reviewers 🙏🏻
- JWT 인증 붙인 상태에서 Postman으로 정상 동작 확인 완료
- 향후 크롤링 대상 도메인 추가 시 `NewsCrawler` 구조 개선 필요성 있음
- 테스트 URL 예시:
  - https://n.news.naver.com/article/437/0000447944

<br>

## 📚 Etc
- 테스트 중 발생한 404 / JWT 예외도 모두 해결함
- 추후 `domain별 크롤러 분리` 또는 `크롤링 fallback 로직 개선` 예정