### PR TITLE
[Feature] #7 - 단어장 관련 API 구현

### DIFF
--- a/src/main/java/dgu/newsee/domain/words/controller/SavedWordController.java
+++ b/src/main/java/dgu/newsee/domain/words/controller/SavedWordController.java
@@ -1,0 +1,72 @@
+package dgu.newsee.domain.words.controller;
+
+import dgu.newsee.domain.words.service.SavedWordService;
+import dgu.newsee.domain.words.dto.SavedWordDTO.WordResponse.SavedWordListResponse;
+import dgu.newsee.domain.words.dto.SavedWordDTO.WordResponse.SaveResult;
+import dgu.newsee.domain.words.dto.SavedWordDTO.WordResponse.DeleteResult;
+import dgu.newsee.global.exception.UserException;
+import dgu.newsee.global.payload.ApiResponse;
+import dgu.newsee.global.payload.ResponseCode;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.*;
+
+
+@RestController
+@RequestMapping("/api/words")
+@RequiredArgsConstructor
+@Tag(name = "Word 컨트롤러", description = "단어장 관련 API")
+public class SavedWordController {
+
+    private final SavedWordService wordService;
+
+    @PostMapping("/{wordId}")
+    @Operation(summary = "단어장에 단어 추가")
+    public ApiResponse<SaveResult> saveWord(Authentication authentication, @PathVariable Long wordId) {
+        if (authentication == null) {
+            throw new UserException(ResponseCode.USER_UNAUTHORIZED);
+        }
+        String userId = authentication.getName();
+        return ApiResponse.success(
+                wordService.saveWord(userId, wordId)
+        );
+    }
+
+    @GetMapping
+    @Operation(summary = "저장한 단어 전체 조회")
+    public ApiResponse<SavedWordListResponse> getAllWords(Authentication authentication) {
+        if (authentication == null) {
+            throw new UserException(ResponseCode.USER_UNAUTHORIZED);
+        }
+        String userId = authentication.getName();
+        return ApiResponse.success(
+                wordService.getAllWords(userId)
+        );
+    }
+
+    @GetMapping("/search")
+    @Operation(summary = "단어장 내 단어 검색")
+    public ApiResponse<SavedWordListResponse> searchWord(Authentication authentication, @RequestParam String keyword) {
+        if (authentication == null) {
+            throw new UserException(ResponseCode.USER_UNAUTHORIZED);
+        }
+        String userId = authentication.getName();
+        return ApiResponse.success(
+                wordService.searchWords(userId, keyword)
+        );
+    }
+
+    @DeleteMapping("/{savedWordId}")
+    @Operation(summary = "단어 삭제 (savedWordId 기준)")
+    public ApiResponse<DeleteResult> deleteWord(Authentication authentication, @PathVariable Long savedWordId) {
+        if (authentication == null) {
+            throw new UserException(ResponseCode.USER_UNAUTHORIZED);
+        }
+        String userId = authentication.getName();
+        return ApiResponse.success(
+                wordService.deleteWord(userId, savedWordId)
+        );
+    }
+}

--- a/src/main/java/dgu/newsee/domain/words/converter/SavedWordConverter.java
+++ b/src/main/java/dgu/newsee/domain/words/converter/SavedWordConverter.java
@@ -1,0 +1,45 @@
+package dgu.newsee.domain.words.converter;
+
+import dgu.newsee.domain.words.entity.SavedWord;
+import dgu.newsee.domain.words.entity.Word;
+import dgu.newsee.domain.words.dto.SavedWordDTO.WordResponse;
+
+import java.util.List;
+
+public class SavedWordConverter {
+
+    public static WordResponse.SaveResult toSaveResult(SavedWord savedWord, Word word) {
+        return WordResponse.SaveResult.builder()
+                .savedWordId(savedWord.getSavedWordId())
+                .wordId(word.getWordId())
+                .term(word.getTerm())
+                .description(word.getDescription())
+                .category(word.getCategory())
+                .date(savedWord.getDate().toString())
+                .build();
+    }
+
+    public static WordResponse.WordDetail toWordDetail(SavedWord savedWord, Word word) {
+        return WordResponse.WordDetail.builder()
+                .savedWordId(savedWord.getSavedWordId())
+                .wordId(word.getWordId())
+                .term(word.getTerm())
+                .description(word.getDescription())
+                .category(word.getCategory())
+                .date(savedWord.getDate().toString())
+                .build();
+    }
+
+    public static WordResponse.SavedWordListResponse toSavedWordListResponse(List<WordResponse.WordDetail> details) {
+        return WordResponse.SavedWordListResponse.builder()
+                .totalCount(details.size())
+                .words(details)
+                .build();
+    }
+
+    public static WordResponse.DeleteResult toDeleteResult(Long savedWordId) {
+        return WordResponse.DeleteResult.builder()
+                .deletedSavedWordId(savedWordId)
+                .build();
+    }
+}

--- a/src/main/java/dgu/newsee/domain/words/dto/SavedWordDTO.java
+++ b/src/main/java/dgu/newsee/domain/words/dto/SavedWordDTO.java
@@ -1,0 +1,57 @@
+package dgu.newsee.domain.words.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+public class SavedWordDTO {
+
+    public static class WordResponse {
+
+        @Getter
+        @Builder
+        @AllArgsConstructor
+        @NoArgsConstructor
+        public static class WordDetail {
+            private Long savedWordId;
+            private Long wordId;
+            private String term;
+            private String description;
+            private String category;
+            private String date;
+        }
+
+        @Getter
+        @Builder
+        @AllArgsConstructor
+        @NoArgsConstructor
+        public static class SavedWordListResponse {
+            private int totalCount;
+            private List<WordDetail> words;
+        }
+
+        @Getter
+        @Builder
+        @AllArgsConstructor
+        @NoArgsConstructor
+        public static class SaveResult {
+            private Long savedWordId;
+            private Long wordId;
+            private String term;
+            private String description;
+            private String category;
+            private String date;
+        }
+
+        @Getter
+        @Builder
+        @AllArgsConstructor
+        @NoArgsConstructor
+        public static class DeleteResult {
+            private Long deletedSavedWordId;
+        }
+    }
+}

--- a/src/main/java/dgu/newsee/domain/words/entity/SavedWord.java
+++ b/src/main/java/dgu/newsee/domain/words/entity/SavedWord.java
@@ -1,0 +1,24 @@
+package dgu.newsee.domain.words.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+import java.time.LocalDate;
+
+@Entity
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@Table(name = "saved_words")
+public class SavedWord {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long savedWordId;
+
+    private Long userId;
+
+    private Long wordId;
+
+    private LocalDate date;
+}

--- a/src/main/java/dgu/newsee/domain/words/entity/Word.java
+++ b/src/main/java/dgu/newsee/domain/words/entity/Word.java
@@ -1,0 +1,26 @@
+package dgu.newsee.domain.words.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@Table(name = "words")
+public class Word {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long wordId;
+
+    private Integer newsId;
+
+    private String term;
+
+    @Column(length = 2000)
+    private String description;
+
+    private String category;
+}

--- a/src/main/java/dgu/newsee/domain/words/repository/SavedWordRepository.java
+++ b/src/main/java/dgu/newsee/domain/words/repository/SavedWordRepository.java
@@ -1,0 +1,14 @@
+package dgu.newsee.domain.words.repository;
+
+import dgu.newsee.domain.words.entity.SavedWord;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.Optional;
+
+@Repository
+public interface SavedWordRepository extends JpaRepository<SavedWord, Long> {
+    List<SavedWord> findByUserId(Long userId);
+    Optional<SavedWord> findByUserIdAndWordId(Long userId, Long wordId);
+}

--- a/src/main/java/dgu/newsee/domain/words/repository/WordRepository.java
+++ b/src/main/java/dgu/newsee/domain/words/repository/WordRepository.java
@@ -1,0 +1,13 @@
+package dgu.newsee.domain.words.repository;
+
+import dgu.newsee.domain.words.entity.Word;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+public interface WordRepository extends JpaRepository<Word, Long> {
+
+    List<Word> findByTermContainingOrDescriptionContaining(String termKeyword, String descKeyword);
+}

--- a/src/main/java/dgu/newsee/domain/words/service/SavedWordService.java
+++ b/src/main/java/dgu/newsee/domain/words/service/SavedWordService.java
@@ -1,0 +1,10 @@
+package dgu.newsee.domain.words.service;
+
+import dgu.newsee.domain.words.dto.SavedWordDTO.WordResponse;
+
+public interface SavedWordService {
+    WordResponse.SaveResult saveWord(String userId, Long wordId);
+    WordResponse.SavedWordListResponse getAllWords(String userId);
+    WordResponse.SavedWordListResponse searchWords(String userId, String keyword);
+    WordResponse.DeleteResult deleteWord(String userId, Long savedWordId);
+}

--- a/src/main/java/dgu/newsee/domain/words/service/SavedWordServiceImpl.java
+++ b/src/main/java/dgu/newsee/domain/words/service/SavedWordServiceImpl.java
@@ -1,0 +1,104 @@
+package dgu.newsee.domain.words.service;
+
+import dgu.newsee.domain.words.converter.SavedWordConverter;
+import dgu.newsee.domain.words.entity.SavedWord;
+import dgu.newsee.domain.words.entity.Word;
+import dgu.newsee.global.exception.UserException;
+import dgu.newsee.global.exception.SavedWordException;
+import dgu.newsee.domain.words.dto.SavedWordDTO.WordResponse;
+import dgu.newsee.domain.words.repository.SavedWordRepository;
+import dgu.newsee.domain.words.repository.WordRepository;
+import dgu.newsee.global.payload.ResponseCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class SavedWordServiceImpl implements SavedWordService {
+
+    private final WordRepository wordRepository;
+    private final SavedWordRepository savedWordRepository;
+
+    @Override
+    public WordResponse.SaveResult saveWord(String userId, Long wordId) {
+        Word word = wordRepository.findById(wordId)
+                .orElseThrow(() -> new SavedWordException(ResponseCode.WORD_NOT_FOUND));
+
+        boolean alreadyExists = savedWordRepository
+                .findByUserIdAndWordId(Long.valueOf(userId), wordId)
+                .isPresent();
+
+        if (alreadyExists) {
+            throw new SavedWordException(ResponseCode.WORD_ALREADY_SAVED);
+        }
+
+        SavedWord savedWord = savedWordRepository.save(
+                SavedWord.builder()
+                        .userId(Long.valueOf(userId))
+                        .wordId(wordId)
+                        .date(LocalDate.now())
+                        .build()
+        );
+
+        return SavedWordConverter.toSaveResult(savedWord, word);
+    }
+
+    @Override
+    public WordResponse.SavedWordListResponse getAllWords(String userId) {
+        List<SavedWord> savedWords = savedWordRepository.findByUserId(Long.valueOf(userId));
+        List<WordResponse.WordDetail> details = new ArrayList<>();
+
+        for (SavedWord savedWord : savedWords) {
+            Word word = wordRepository.findById(savedWord.getWordId())
+                    .orElseThrow(() -> new SavedWordException(ResponseCode.WORD_NOT_FOUND));
+            details.add(SavedWordConverter.toWordDetail(savedWord, word));
+        }
+
+        return WordResponse.SavedWordListResponse.builder()
+                .totalCount(details.size())
+                .words(details)
+                .build();
+    }
+
+    @Override
+    public WordResponse.SavedWordListResponse searchWords(String userId, String keyword) {
+        List<Word> words;
+
+        if (keyword == null || keyword.isEmpty()) {
+            words = wordRepository.findAll();
+        } else {
+            words = wordRepository.findByTermContainingOrDescriptionContaining(keyword, keyword);
+        }
+
+        List<WordResponse.WordDetail> result = new ArrayList<>();
+
+        for (Word word : words) {
+            savedWordRepository.findByUserIdAndWordId(Long.valueOf(userId), word.getWordId())
+                    .ifPresent(savedWord ->
+                            result.add(SavedWordConverter.toWordDetail(savedWord, word))
+                    );
+        }
+
+        return SavedWordConverter.toSavedWordListResponse(result);
+    }
+
+    @Override
+    public WordResponse.DeleteResult deleteWord(String userId, Long savedWordId) {
+        SavedWord savedWord = savedWordRepository.findById(savedWordId)
+                .orElseThrow(() -> new SavedWordException(ResponseCode.WORD_NOT_FOUND));
+
+        if (!savedWord.getUserId().equals(Long.valueOf(userId))) {
+            throw new UserException(ResponseCode.USER_FORBIDDEN);
+        }
+
+        savedWordRepository.delete(savedWord);
+
+        return SavedWordConverter.toDeleteResult(savedWordId);
+    }
+}

--- a/src/main/java/dgu/newsee/global/exception/SavedWordException.java
+++ b/src/main/java/dgu/newsee/global/exception/SavedWordException.java
@@ -1,0 +1,9 @@
+package dgu.newsee.global.exception;
+
+import dgu.newsee.global.payload.BaseErrorCode;
+
+public class SavedWordException extends GeneralException {
+    public SavedWordException(BaseErrorCode code) {
+        super(code);
+    }
+}

--- a/src/main/java/dgu/newsee/global/payload/ResponseCode.java
+++ b/src/main/java/dgu/newsee/global/payload/ResponseCode.java
@@ -10,6 +10,7 @@ public enum ResponseCode implements BaseErrorCode {
     // ✅ 공통
     COMMON_SUCCESS(ResponseCodeType.SUCCESS, "COMMON200", "성공입니다.", HttpStatus.OK),
     COMMON_FAIL(ResponseCodeType.ERROR, "COMMON500", "서버 오류입니다.", HttpStatus.INTERNAL_SERVER_ERROR),
+    COMMON_NOT_FOUND(ResponseCodeType.ERROR, "COMMON404", "요청한 리소스를 찾을 수 없습니다.", HttpStatus.NOT_FOUND),
 
     // ✅ 인증 관련
     USER_UNAUTHORIZED(ResponseCodeType.ERROR, "AUTH401", "인증되지 않은 사용자입니다.", HttpStatus.UNAUTHORIZED),


### PR DESCRIPTION
## Related Issue 🍀
- close #7 

<br>

## Key Changes 🔑
아래의 3개의 API 구현
- 단어장에 단어 추가(POST)
- 단어장에서 단어 삭제(DELETE)
- 단어장 내 단어 검색(GET)
- 저장한 단어 조회(총 개수 & 리스트)(GET)

<br>
