### PR TITLE
✨ [Feature] #27 - 뉴스 크롤링 자동화 시스템 및 테스트 API 구현

### DIFF
--- a/src/main/java/dgu/newsee/NewseeApplication.java
+++ b/src/main/java/dgu/newsee/NewseeApplication.java
@@ -3,9 +3,11 @@ package dgu.newsee;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication
 @EnableJpaAuditing
+@EnableScheduling
 public class NewseeApplication {
 
 	public static void main(String[] args) {

--- a/src/main/java/dgu/newsee/domain/crawlednews/controller/CrawledNewsTestController.java
+++ b/src/main/java/dgu/newsee/domain/crawlednews/controller/CrawledNewsTestController.java
@@ -1,0 +1,19 @@
+package dgu.newsee.domain.crawlednews.controller;
+
+import dgu.newsee.domain.crawlednews.service.CrawledNewsScheduler;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/test/crawled-news")
+@RequiredArgsConstructor
+public class CrawledNewsTestController {
+
+    private final CrawledNewsScheduler scheduler;
+
+    @PostMapping("/run")
+    public String runSchedulerManually() {
+        scheduler.crawlNewsPeriodically();
+        return "크롤링 스케줄러 수동 실행 완료";
+    }
+}

--- a/src/main/java/dgu/newsee/domain/crawlednews/entity/CrawledNews.java
+++ b/src/main/java/dgu/newsee/domain/crawlednews/entity/CrawledNews.java
@@ -1,0 +1,32 @@
+package dgu.newsee.domain.crawlednews.entity;
+
+import dgu.newsee.global.common.BaseEntity;
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+public class CrawledNews extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String title;
+
+    @Lob
+    private String content;
+
+    private String category;
+
+    private String source;
+
+    private LocalDateTime time;
+
+    private String originalUrl;
+}

--- a/src/main/java/dgu/newsee/domain/crawlednews/repository/CrawledNewsRepository.java
+++ b/src/main/java/dgu/newsee/domain/crawlednews/repository/CrawledNewsRepository.java
@@ -1,0 +1,8 @@
+package dgu.newsee.domain.crawlednews.repository;
+
+import dgu.newsee.domain.crawlednews.entity.CrawledNews;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface CrawledNewsRepository extends JpaRepository<CrawledNews, Long> {
+    boolean existsByOriginalUrl(String url);
+}

--- a/src/main/java/dgu/newsee/domain/crawlednews/service/CrawledNewsScheduler.java
+++ b/src/main/java/dgu/newsee/domain/crawlednews/service/CrawledNewsScheduler.java
@@ -1,0 +1,36 @@
+package dgu.newsee.domain.crawlednews.service;
+
+import dgu.newsee.domain.crawlednews.util.SectionUrlCollector;
+import lombok.RequiredArgsConstructor;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+import java.util.Map;
+
+@Component
+@RequiredArgsConstructor
+public class CrawledNewsScheduler {
+
+    private final CrawledNewsService service;
+    private final SectionUrlCollector collector;
+
+    private final Map<String, String> categoryMap = Map.of(
+            "정치", "https://news.naver.com/section/100",
+            "경제", "https://news.naver.com/section/101",
+            "사회", "https://news.naver.com/section/102",
+            "생활/문화", "https://news.naver.com/section/103",
+            "IT/과학", "https://news.naver.com/section/105",
+            "세계", "https://news.naver.com/section/104"
+    );
+
+    @Scheduled(cron = "0 0 */12 * * *") // 12시간마다
+    public void crawlNewsPeriodically() {
+        for (String category : categoryMap.keySet()) {
+            String sectionUrl = categoryMap.get(category);
+            List<String> urls = collector.collect(sectionUrl);
+            urls.stream().limit(10).forEach(url -> service.crawlAndSave(url, category));
+        }
+    }
+}
+

--- a/src/main/java/dgu/newsee/domain/crawlednews/service/CrawledNewsService.java
+++ b/src/main/java/dgu/newsee/domain/crawlednews/service/CrawledNewsService.java
@@ -1,0 +1,43 @@
+package dgu.newsee.domain.crawlednews.service;
+
+import dgu.newsee.domain.crawlednews.entity.CrawledNews;
+import dgu.newsee.domain.crawlednews.repository.CrawledNewsRepository;
+import dgu.newsee.domain.crawlednews.util.CrawledNewsCrawler;
+import dgu.newsee.domain.crawlednews.util.CrawledNewsResult;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class CrawledNewsService {
+
+    private final CrawledNewsCrawler crawler;
+    private final CrawledNewsRepository repository;
+
+    @Transactional
+    public void crawlAndSave(String url, String category) {
+        String normalizedUrl = url.replace("/comment", "").split("\\?")[0];
+
+        if (repository.existsByOriginalUrl(normalizedUrl)) {
+            System.out.println("중복된 뉴스 URL → 저장하지 않음: " + normalizedUrl);
+            return;
+        }
+
+        try {
+            CrawledNewsResult result = crawler.crawl(normalizedUrl, category);
+            CrawledNews news = CrawledNews.builder()
+                    .title(result.getTitle())
+                    .content(result.getContent())
+                    .category(result.getCategory())
+                    .source(result.getSource())
+                    .time(result.getTime())
+                    .originalUrl(normalizedUrl)
+                    .build();
+            repository.save(news);
+            System.out.println("크롤링 및 저장 완료: " + normalizedUrl);
+        } catch (Exception e) {
+            System.err.println("크롤링 실패: " + normalizedUrl + " → " + e.getMessage());
+        }
+    }
+}

--- a/src/main/java/dgu/newsee/domain/crawlednews/util/CrawledNewsCrawler.java
+++ b/src/main/java/dgu/newsee/domain/crawlednews/util/CrawledNewsCrawler.java
@@ -1,0 +1,34 @@
+package dgu.newsee.domain.crawlednews.util;
+
+import org.jsoup.Jsoup;
+import org.jsoup.nodes.Document;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+
+@Component
+public class CrawledNewsCrawler {
+
+    public CrawledNewsResult crawl(String url, String category) throws IOException {
+        Document doc = Jsoup.connect(url).get();
+
+        String title = doc.select("meta[property=og:title]").attr("content");
+        String content = doc.select("#dic_area").text();
+        String source = doc.select("meta[property=og:article:author]").attr("content");
+        if (source.isBlank()) {
+            source = doc.select("meta[property=og:site_name]").attr("content");
+        }
+
+        String rawTime = doc.select("meta[property=og:article:published_time]").attr("content");
+        LocalDateTime time;
+        try {
+            time = LocalDateTime.parse(rawTime, DateTimeFormatter.ISO_OFFSET_DATE_TIME);
+        } catch (Exception e) {
+            time = LocalDateTime.now();
+        }
+
+        return new CrawledNewsResult(title, content, category, source, time, url);
+    }
+}

--- a/src/main/java/dgu/newsee/domain/crawlednews/util/CrawledNewsResult.java
+++ b/src/main/java/dgu/newsee/domain/crawlednews/util/CrawledNewsResult.java
@@ -1,0 +1,17 @@
+package dgu.newsee.domain.crawlednews.util;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@AllArgsConstructor
+public class CrawledNewsResult {
+    private String title;
+    private String content;
+    private String category;
+    private String source;
+    private LocalDateTime time;
+    private String url;
+}

--- a/src/main/java/dgu/newsee/domain/crawlednews/util/SectionUrlCollector.java
+++ b/src/main/java/dgu/newsee/domain/crawlednews/util/SectionUrlCollector.java
@@ -1,0 +1,35 @@
+package dgu.newsee.domain.crawlednews.util;
+
+import lombok.extern.slf4j.Slf4j;
+import org.jsoup.Jsoup;
+import org.jsoup.nodes.Document;
+import org.jsoup.select.Elements;
+import org.springframework.stereotype.Component;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Slf4j
+@Component
+public class SectionUrlCollector {
+
+    public List<String> collect(String sectionUrl) {
+        List<String> articleUrls = new ArrayList<>();
+
+        try {
+            Document doc = Jsoup.connect(sectionUrl).get();
+            Elements links = doc.select("a[href^=https://n.news.naver.com/mnews/article/]");
+
+            for (var link : links) {
+                String href = link.attr("abs:href");
+                if (!articleUrls.contains(href)) {
+                    articleUrls.add(href);
+                }
+            }
+        } catch (Exception e) {
+            log.error("뉴스 링크 수집 실패 - {}", sectionUrl, e);
+        }
+
+        return articleUrls;
+    }
+}

--- a/src/main/java/dgu/newsee/global/config/SecurityConfig.java
+++ b/src/main/java/dgu/newsee/global/config/SecurityConfig.java
@@ -37,7 +37,8 @@ public class SecurityConfig {
                                 "/v3/api-docs/**",
                                 "/api/user/kakao",
                                 "/api/url/news",
-                                "/api/user/level"
+                                "/api/user/level",
+                                "/api/test/crawled-news/**"
                         ).permitAll()
                         .anyRequest().authenticated()
                 )

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -17,3 +17,10 @@ spring:
     url: ${DB_URL}
     username: ${DB_USERNAME}
     password: ${DB_PASSWORD}
+
+  task:
+    scheduling:
+      pool:
+        size: 3
+    main:
+      allow-bean-definition-overriding: true


### PR DESCRIPTION
## Related Issue 🍀
- #27 

<br>

## Key Changes 🔑
- CrawledNews 테이블과 엔티티 생성 및 저장 로직 구현
- 카테고리별 네이버 뉴스 URL을 기반으로 12시간마다 자동 크롤링 기능 추가 (@Scheduled)
- 뉴스 URL 저장 시 /comment 경로 및 파라미터 제거하여 중복 저장 방지
- 수동 실행용 테스트용 API (/api/news/crawl/test) 추가
- 크롤링 대상 URL 정규화(.replace("/comment", "").split("?")[0]) 로직 추가
- original_url 저장 시도 전 중복 확인을 통해 중복 데이터 제거


<br>

## To Reviewers 🙏🏻
- 크롤링된 뉴스는 crawled_news 테이블에 저장되며, 사용자 수집 뉴스와 분리되어 관리됩니다.
- 추후 카테고리별 URL 목록은 YAML 설정 등으로 분리 가능성 고려 바랍니다.
- 중복 저장 방지를 위한 URL 정규화 로직이 핵심이므로 참고 바랍니다.
- 테스트 시 자동 스케줄링 외에도 수동 API로 기능 확인 가능합니다.