### PR TITLE
[Feature] #9 - 뉴스 관련 API 추가

### DIFF
--- a/src/main/java/dgu/newsee/domain/news/controller/UserNewsController.java
+++ b/src/main/java/dgu/newsee/domain/news/controller/UserNewsController.java
@@ -2,10 +2,8 @@ package dgu.newsee.domain.news.controller;
 
 import dgu.newsee.domain.news.dto.NewsDetailDTO;
 import dgu.newsee.domain.news.dto.NewsDTO;
-import dgu.newsee.domain.news.dto.SavedNewsDTO;
 import dgu.newsee.domain.news.service.NewsService;
-import dgu.newsee.domain.user.entity.Level;
-import dgu.newsee.domain.user.entity.User;
+import dgu.newsee.domain.news.util.SecurityUtil;
 import dgu.newsee.domain.user.repository.UserRepository;
 import dgu.newsee.global.exception.NewsException;
 import dgu.newsee.global.payload.ApiResponse;
@@ -28,38 +26,28 @@ public class UserNewsController {
     @GetMapping
     @Operation(summary = "전체 뉴스 조회 (비회원은 중 레벨)")
     public ApiResponse<List<NewsDTO>> getAllNews(Authentication authentication) {
-        Long userId = extractUserId(authentication);
+        Long userId = SecurityUtil.extractUserId(authentication);
         return newsService.getAllNews(userId, null);
     }
 
     @GetMapping("/{newsId}")
     @Operation(summary = "뉴스 상세 조회 (비회원은 중 레벨)")
     public ApiResponse<NewsDetailDTO> getNewsDetail(@PathVariable Long newsId, Authentication authentication) {
-        Long userId = extractUserId(authentication);
+        Long userId = SecurityUtil.extractUserId(authentication);
         return newsService.getNewsDetail(newsId, userId, null);
     }
 
     @GetMapping("/search")
     @Operation(summary = "뉴스 검색 (비회원은 중 레벨)")
     public ApiResponse<List<NewsDTO>> searchNews(@RequestParam String keyword, Authentication authentication) {
-        Long userId = extractUserId(authentication);
+        Long userId = SecurityUtil.extractUserId(authentication);
         return newsService.searchNews(keyword, userId, null);
-    }
-
-    @GetMapping("/user/saved-news")
-    @Operation(summary = "북마크한 뉴스 목록 조회 (회원만 가능)")
-    public ApiResponse<List<SavedNewsDTO>> getSavedNews(Authentication authentication) {
-        Long userId = extractUserId(authentication);
-        if (userId == null) {
-            throw new NewsException(ResponseCode.USER_UNAUTHORIZED);
-        }
-        return newsService.getSavedNews(userId, null);
     }
 
     @PostMapping("/{newsId}")
     @Operation(summary = "뉴스 북마크 저장 (회원만 가능)")
     public ApiResponse<?> saveNews(@PathVariable Long newsId, Authentication authentication) {
-        Long userId = extractUserId(authentication);
+        Long userId = SecurityUtil.extractUserId(authentication);
 
         if (userId == null) {
             throw new NewsException(ResponseCode.USER_UNAUTHORIZED);
@@ -74,7 +62,7 @@ public class UserNewsController {
             @PathVariable Long savedNewsId,
             Authentication authentication
     ) {
-        Long userId = extractUserId(authentication);
+        Long userId = SecurityUtil.extractUserId(authentication);
 
         if (userId == null) {
             throw new NewsException(ResponseCode.USER_UNAUTHORIZED);
@@ -83,10 +71,4 @@ public class UserNewsController {
         return newsService.deleteNewsBookmark(userId, savedNewsId);
     }
 
-    private Long extractUserId(Authentication authentication) {
-        if (authentication == null || authentication.getName() == null) {
-            return null;
-        }
-        return Long.parseLong(authentication.getName());
-    }
 }

--- a/src/main/java/dgu/newsee/domain/news/converter/NewsConverter.java
+++ b/src/main/java/dgu/newsee/domain/news/converter/NewsConverter.java
@@ -58,7 +58,6 @@ public class NewsConverter {
                 .time(origin.getTime().toString())
                 .url(origin.getOriginalUrl())
                 .imageUrl(origin.getImageUrl())
-                .userLevel(userLevel)
                 .isBookmarked(isBookmarked)
                 .transformedContent(transformed.getTransformedContent())
                 .summary(transformed.getSummarized())

--- a/src/main/java/dgu/newsee/domain/news/dto/NewsDetailDTO.java
+++ b/src/main/java/dgu/newsee/domain/news/dto/NewsDetailDTO.java
@@ -18,7 +18,6 @@ public class NewsDetailDTO {
     private String time;
     private String url;
     private String imageUrl;
-    private String userLevel;
     private boolean isBookmarked;
 
     @JsonProperty("isBookmarked")

--- a/src/main/java/dgu/newsee/domain/news/util/SecurityUtil.java
+++ b/src/main/java/dgu/newsee/domain/news/util/SecurityUtil.java
@@ -1,0 +1,13 @@
+package dgu.newsee.domain.news.util;
+
+import org.springframework.security.core.Authentication;
+
+public class SecurityUtil {
+
+    public static Long extractUserId(Authentication authentication) {
+        if (authentication == null || authentication.getName() == null) {
+            return null;
+        }
+        return Long.parseLong(authentication.getName());
+    }
+}

--- a/src/main/java/dgu/newsee/domain/user/controller/UserBookmarkController.java
+++ b/src/main/java/dgu/newsee/domain/user/controller/UserBookmarkController.java
@@ -1,0 +1,34 @@
+package dgu.newsee.domain.user.controller;
+
+import dgu.newsee.domain.news.dto.SavedNewsDTO;
+import dgu.newsee.domain.news.service.NewsService;
+import dgu.newsee.global.exception.NewsException;
+import dgu.newsee.global.payload.ApiResponse;
+import dgu.newsee.global.payload.ResponseCode;
+import io.swagger.v3.oas.annotations.Operation;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import dgu.newsee.domain.news.util.SecurityUtil;
+
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/user/saved-news")
+public class UserBookmarkController {
+
+    private final NewsService newsService;
+
+    @GetMapping
+    @Operation(summary = "북마크한 뉴스 목록 조회 (회원만 가능)")
+    public ApiResponse<List<SavedNewsDTO>> getSavedNews(Authentication authentication) {
+        Long userId = SecurityUtil.extractUserId(authentication);
+        if (userId == null) {
+            throw new NewsException(ResponseCode.USER_UNAUTHORIZED);
+        }
+        return newsService.getSavedNews(userId, null);
+    }
+}


### PR DESCRIPTION
## Related Issue 🍀
- close #9 , close #8 

<br>

## Key Changes 🔑
- 뉴스 상세 API keyword 포함하도록 수정
- 북마크 뉴스 조회는 UserBookmarkController로 분리
- SecurityUtil을 통해 extractUserId (authentication 방식) 분리