### PR TITLE
[Refactor] #56 - AI 변환 서버 URL을 코드 하드코딩 대신 application.yml의 환경변수로 분리

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -17,6 +17,7 @@ jobs:
       DB_USERNAME: ${{ secrets.DB_USERNAME }}
       DB_PASSWORD: ${{ secrets.DB_PASSWORD }}
       JWT_SECRET_KEY: ${{ secrets.JWT_SECRET_KEY }}
+      EXTERNAL_AI_URL: ${{ EXTERNAL_AI_URL}}
 
     steps:
       - uses: actions/checkout@v4
@@ -68,6 +69,7 @@ jobs:
             echo "DB_USERNAME=${{ secrets.DB_USERNAME }}" >> ~/.env
             echo "DB_PASSWORD=${{ secrets.DB_PASSWORD }}" >> ~/.env
             echo "JWT_SECRET_KEY=${{ secrets.JWT_SECRET_KEY }}" >> ~/.env
+            echo "EXTERNAL_AI_URL=${{ secrets.EXTERNAL_AI_URL }}" >> ~/.env
             
             # 새 컨테이너 실행 및 환경 변수 전달
             sudo docker run -d --log-driver=syslog --name docker-test -p 8080:8080 \

--- a/src/main/java/dgu/newsee/domain/transformednews/service/TransformedNewsService.java
+++ b/src/main/java/dgu/newsee/domain/transformednews/service/TransformedNewsService.java
@@ -36,6 +36,8 @@ public class TransformedNewsService {
     @Value("${external.ai.url}")
     private String aiServerUrl;
 
+    private final String transformPath = "/api/news/transfer";
+
     private final ObjectMapper objectMapper = new ObjectMapper();
 
     @Transactional
@@ -56,10 +58,13 @@ public class TransformedNewsService {
                 level
         );
 
+        // ai 서버 url + transformPath
+        String requestUrl = aiServerUrl + transformPath;
+
         // 요청 로그 출력
         try {
             System.out.println("\n==== [AI 서버 요청 전송] ====");
-            System.out.println("요청 URL: " + aiServerUrl);
+            System.out.println("요청 URL: " + requestUrl);
             System.out.println("요청 JSON: " + objectMapper.writeValueAsString(request));
         } catch (Exception e) {
             System.out.println("요청 JSON 직렬화 실패: " + e.getMessage());
@@ -73,7 +78,7 @@ public class TransformedNewsService {
 
         try {
             response = restTemplate.exchange(
-                    aiServerUrl,
+                    requestUrl,
                     HttpMethod.POST,
                     entity,
                     new ParameterizedTypeReference<>() {}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -23,8 +23,8 @@ spring:
       pool:
         size: 3
     main:
-      allow-bean-definition-overriding: true\
+      allow-bean-definition-overriding: true
 
 external:
   ai:
-    url: https://0b96a22855d0.ngrok-free.app/api/news/transfer
+    url: ${EXTERNAL_AI_URL}


### PR DESCRIPTION
## Related Issue 🍀
- #56 

<br>

## Key Changes 🔑
- @Value("${external.ai.url}")을 통해 URL 주입
- AI base URL과 엔드포인트 경로 분리 (환경변수에는 도메인까지만 입력)

<br>

## To Reviewers 🙏🏻
- 